### PR TITLE
[Matrix|N*] depends update, fixes, year increase and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 This is a [Kodi](https://kodi.tv) audio decoder addon for NCSF files.
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://travis-ci.org/xbmc/audiodecoder.ncsf.svg?branch=Matrix)](https://travis-ci.org/xbmc/audiodecoder.ncsf/branches)
 [![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audiodecoder.ncsf?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=8&branchName=Matrix)
 [![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/audiodecoder.ncsf/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudiodecoder.ncsf/branches/)
 <!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/audiodecoder.ncsf?branch=Matrix&svg=true)](https://ci.appveyor.com/project/xbmc/audiodecoder-ncsf?branch=Matrix) -->

--- a/audiodecoder.ncsf/addon.xml.in
+++ b/audiodecoder.ncsf/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audiodecoder.ncsf"
-  version="3.0.0"
+  version="3.0.1"
   name="NCSF Audio Decoder"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,7 +3,7 @@ Upstream-Name: audiodecoder.ncsf
 Source: https://github.com/xbmc/audiodecoder.2sf
 
 Files: *
-Copyright: 2005-2020 Team Kodi
+Copyright: 2005-2021 Team Kodi
 License: GPL-2+
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/lib/SSEQPlayer/Player.cpp
+++ b/lib/SSEQPlayer/Player.cpp
@@ -148,7 +148,7 @@ int Player::TrackAlloc()
 // Original FSS Function: Player_Run
 void Player::Run()
 {
-	while (this->tempoCount > 240)
+	while (this->tempoCount >= 240)
 	{
 		this->tempoCount -= 240;
 		for (uint8_t i = 0; i < this->nTracks; ++i)

--- a/lib/kodi-SSEQPlayer-note.txt
+++ b/lib/kodi-SSEQPlayer-note.txt
@@ -1,4 +1,5 @@
-SSEQPlayer source from https://g.losno.co/chris/SSEQPlayer
-Sync to 1778b651ed (5 Aug 2020)
+SSEQPlayer source from https://git.lopez-snowhill.net/chris/sseqplayer
+Sync to 369f23b1 (16 March 2021)
 
-Old source https://github.com/kode54/SSEQPlayer
+Old source:
+- https://github.com/kode54/SSEQPlayer

--- a/lib/kodi-psflib-note.txt
+++ b/lib/kodi-psflib-note.txt
@@ -1,4 +1,2 @@
-psflib source from https://g.losno.co/chris/psflib
-Sync to 591f2a3b31 (25 May 2020)
-
-Old source https://github.com/kode54/psflib (38b1419 (28 Feb 2020))
+psflib source from https://github.com/kode54/psflib
+Sync to 77dfb4a (17 March 2021)

--- a/lib/psflib/psf2fs.c
+++ b/lib/psflib/psf2fs.c
@@ -414,7 +414,7 @@ static int virtual_read(struct PSF2FS *fs, struct DIR_ENTRY *entry, int offset, 
       destlen = block_usize;
       // attempt decompress
       r = uncompress((unsigned char *) fs->cacheblock.uncompressed_data, &destlen, (const unsigned char *) entry->source->reserved_data + block_zofs, block_zsize);
-      if(r != Z_OK || destlen != block_usize) {
+      if(r != Z_OK || destlen != (unsigned long)block_usize) {
 //        char s[999];
 //        sprintf(s,"zdata=%02X %02X %02X blockz=%d blocku=%d destlenout=%d", zdata[0], zdata[1], zdata[2], block_zsize, block_usize, destlen);
 //        errormessageadd(fs, s);


### PR DESCRIPTION
This update:
- psflib to latest version
- SSEQPlayer to latest version
- Remove the status badge about Travis CI
  - The build script stais currently in, maybe usable for something else or they allow again a bit more by travis.com
- Set copyright year to 2021

Performed compile and run test on Linux with C++14, C++17 and C++20.
Runtime tests was OK.